### PR TITLE
fs: refactor unlinksync logic in rimraf

### DIFF
--- a/_unlinksync.csv
+++ b/_unlinksync.csv
@@ -1,0 +1,1 @@
+"binary","filename","configuration","rate","time"

--- a/benchmark/fs/bench-rimrafUnlinkSync.js
+++ b/benchmark/fs/bench-rimrafUnlinkSync.js
@@ -1,0 +1,53 @@
+'use strict';
+
+const assert = require('assert');
+const common = require('../common');
+const fs = require('fs');
+const tmpdir = require('../../test/common/tmpdir');
+tmpdir.refresh();
+
+const bench = common.createBenchmark(main, {
+  type: ['existing', 'non-existing'],
+  n: [1e3],
+});
+
+function main({ n, type }) {
+  switch (type) {
+    case 'existing': {
+      for (let i = 0; i < n; i++) {
+        fs.writeFileSync(tmpdir.resolve(`rimrafunlinksync-bench-dir-${i}`), '');
+      }
+
+      bench.start();
+      for (let i = 0; i < n; i++) {
+        try {
+          fs.rmSync(tmpdir.resolve(`rimrafunlinksync-bench-dir-${i}`), {
+            recursive: true, // required to enter rimraf path
+            maxRetries: 3,
+          });
+        } catch (err) {
+          throw err;
+        }
+      }
+      bench.end(n);
+      break;
+    }
+    case 'non-existing': {
+      bench.start();
+      for (let i = 0; i < n; i++) {
+        try {
+          fs.rmSync(tmpdir.resolve(`.non-existent-folder-${i}`), {
+            recursive: true, // required to enter rimraf path
+            maxRetries: 3,
+          });
+        } catch (err) {
+          assert.ok(err);
+        }
+      }
+      bench.end(n);
+      break;
+    }
+    default:
+      new Error('Invalid type');
+  }
+}

--- a/benchmark/fs/bench-rmdirSync.js
+++ b/benchmark/fs/bench-rmdirSync.js
@@ -15,15 +15,14 @@ function main({ n, type }) {
   switch (type) {
     case 'existing': {
       for (let i = 0; i < n; i++) {
-        const p = tmpdir.resolve(`rmdirsync-bench-dir-${i}`);
-        fs.mkdirSync(p, { recursive: true });
+        fs.mkdirSync(tmpdir.resolve(`rmsync-bench-dir-${i}`), {
+          recursive: true,
+        });
       }
 
       bench.start();
       for (let i = 0; i < n; i++) {
-        const p = tmpdir.resolve(`rmdirsync-bench-dir-${i}`);
-
-        fs.rmdirSync(p, {
+        fs.rmSync(tmpdir.resolve(`rmsync-bench-dir-${i}`), {
           recursive: true,
           maxRetries: 3,
         });
@@ -35,7 +34,7 @@ function main({ n, type }) {
       bench.start();
       for (let i = 0; i < n; i++) {
         try {
-          fs.rmdirSync(tmpdir.resolve(`.non-existent-folder-${i}`), {
+          fs.rmSync(tmpdir.resolve(`.non-existent-folder-${i}`), {
             recursive: true,
             maxRetries: 3,
           });

--- a/benchmark/fs/bench-rmdirSync.js
+++ b/benchmark/fs/bench-rmdirSync.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const assert = require('assert');
 const common = require('../common');
 const fs = require('fs');
 const tmpdir = require('../../test/common/tmpdir');
@@ -36,9 +37,10 @@ function main({ n, type }) {
         try {
           fs.rmdirSync(tmpdir.resolve(`.non-existent-folder-${i}`), {
             recursive: true,
+            maxRetries: 3,
           });
-        } catch {
-          // do nothing
+        } catch (err) {
+          assert.match(err.message, /ENOENT/);
         }
       }
       bench.end(n);

--- a/benchmark/fs/bench-rmdirSync.js
+++ b/benchmark/fs/bench-rmdirSync.js
@@ -1,0 +1,50 @@
+'use strict';
+
+const common = require('../common');
+const fs = require('fs');
+const tmpdir = require('../../test/common/tmpdir');
+tmpdir.refresh();
+
+const bench = common.createBenchmark(main, {
+  type: ['existing', 'non-existing'],
+  n: [1e3],
+});
+
+function main({ n, type }) {
+  switch (type) {
+    case 'existing': {
+      for (let i = 0; i < n; i++) {
+        const p = tmpdir.resolve(`rmdirsync-bench-dir-${i}`);
+        fs.mkdirSync(p, { recursive: true });
+      }
+
+      bench.start();
+      for (let i = 0; i < n; i++) {
+        const p = tmpdir.resolve(`rmdirsync-bench-dir-${i}`);
+
+        fs.rmdirSync(p, {
+          recursive: true,
+          maxRetries: 3,
+        });
+      }
+      bench.end(n);
+      break;
+    }
+    case 'non-existing': {
+      bench.start();
+      for (let i = 0; i < n; i++) {
+        try {
+          fs.rmdirSync(tmpdir.resolve(`.non-existent-folder-${i}`), {
+            recursive: true,
+          });
+        } catch {
+          // do nothing
+        }
+      }
+      bench.end(n);
+      break;
+    }
+    default:
+      new Error('Invalid type');
+  }
+}

--- a/lib/internal/fs/rimraf.js
+++ b/lib/internal/fs/rimraf.js
@@ -14,6 +14,7 @@ const {
 
 const { Buffer } = require('buffer');
 const fs = require('fs');
+const fsBinding = internalBinding('fs');
 const {
   chmod,
   chmodSync,
@@ -26,7 +27,6 @@ const {
   stat,
   statSync,
   unlink,
-  unlinkSync,
 } = fs;
 const { sep } = require('path');
 const { setTimeout } = require('timers');
@@ -39,7 +39,6 @@ const epermHandler = isWindows ? fixWinEPERM : _rmdir;
 const epermHandlerSync = isWindows ? fixWinEPERMSync : _rmdirSync;
 const readdirEncoding = 'buffer';
 const separator = Buffer.from(sep);
-
 
 function rimraf(path, options, callback) {
   let retries = 0;
@@ -192,7 +191,7 @@ function rimrafSync(path, options) {
     if (stats?.isDirectory())
       _rmdirSync(path, options, null);
     else
-      _unlinkSync(path, options);
+      fsBinding.rimrafUnlinkSync(path, options.maxRetries, options.retryDelay);
   } catch (err) {
     if (err.code === 'ENOENT')
       return;
@@ -204,31 +203,6 @@ function rimrafSync(path, options) {
     _rmdirSync(path, options, err);
   }
 }
-
-
-function _unlinkSync(path, options) {
-  const tries = options.maxRetries + 1;
-
-  for (let i = 1; i <= tries; i++) {
-    try {
-      return unlinkSync(path);
-    } catch (err) {
-      // Only sleep if this is not the last try, and the delay is greater
-      // than zero, and an error was encountered that warrants a retry.
-      if (retryErrorCodes.has(err.code) &&
-          i < tries &&
-          options.retryDelay > 0) {
-        sleep(i * options.retryDelay);
-      } else if (err.code === 'ENOENT') {
-        // The file is already gone.
-        return;
-      } else if (i === tries) {
-        throw err;
-      }
-    }
-  }
-}
-
 
 function _rmdirSync(path, options, originalErr) {
   try {
@@ -303,7 +277,7 @@ function fixWinEPERMSync(path, options, originalErr) {
   if (stats.isDirectory())
     _rmdirSync(path, options, originalErr);
   else
-    _unlinkSync(path, options);
+    fsBinding.rimrafUnlinkSync(path, options.maxRetries, options.retryDelay);
 }
 
 

--- a/node.gyp
+++ b/node.gyp
@@ -106,6 +106,7 @@
       'src/node_errors.cc',
       'src/node_external_reference.cc',
       'src/node_file.cc',
+      'src/node_file_rimraf.cc',
       'src/node_http_parser.cc',
       'src/node_http2.cc',
       'src/node_i18n.cc',

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -1622,7 +1622,6 @@ static void RimrafUnlinkSync(const FunctionCallbackInfo<Value>& args) {
     if (is_uv_error(err)) {
       if (i < tries && retry_delay > 0 &&
           std::find(retryable_errors.begin(), retryable_errors.end(), err) != retryable_errors.end()) {
-            printf("unlink retrying %d\n", i);
         sleep(i * retry_delay * 1e-3);
       } else if (err == UV_ENOENT) {
         break;

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -49,6 +49,12 @@
 # include <io.h>
 #endif
 
+#if defined(_WIN32)
+#include<windows.h>           // for windows
+#else
+#include<unistd.h>               // for linux 
+#endif
+
 #include <memory>
 
 namespace node {
@@ -1585,6 +1591,46 @@ static void RMDir(const FunctionCallbackInfo<Value>& args) {
     SyncCall(env, args[2], &req_wrap_sync, "rmdir",
              uv_fs_rmdir, *path);
     FS_SYNC_TRACE_END(rmdir);
+  }
+}
+
+static void RimrafUnlinkSync(const FunctionCallbackInfo<Value>& args) {
+  const int argc = args.Length();
+  CHECK_EQ(argc, 3);  // path, retries, retrydelay
+
+  CHECK(args[1]->IsInt32());
+  CHECK(args[2]->IsInt32());
+
+  Environment* env = Environment::GetCurrent(args);
+  BufferValue path(env->isolate(), args[0]);
+
+  THROW_IF_INSUFFICIENT_PERMISSIONS(
+      env, permission::PermissionScope::kFileSystemWrite, path.ToStringView());
+
+  const auto tries = args[1].As<Int32>()->Value() + 1;
+  const auto retry_delay = args[2].As<Int32>()->Value();
+  constexpr std::array<int, 5> retryable_errors = {
+      EBUSY, EMFILE, ENFILE, ENOTEMPTY, EPERM};
+
+  uv_fs_t req;
+
+  for (int i = 1; i <= tries; i++) {
+    FS_SYNC_TRACE_BEGIN(unlink);
+    auto err = uv_fs_unlink(nullptr, &req, *path, nullptr);
+    FS_SYNC_TRACE_END(unlink);
+
+    if (is_uv_error(err)) {
+      if (i < tries && retry_delay > 0 &&
+          std::find(retryable_errors.begin(), retryable_errors.end(), err) != retryable_errors.end()) {
+            printf("unlink retrying %d\n", i);
+        sleep(i * retry_delay * 1e-3);
+      } else if (err == UV_ENOENT) {
+        break;
+      } else if (i == tries) {
+        env->ThrowUVException(err, nullptr, "unlink");
+        break;
+      }
+    }
   }
 }
 
@@ -3253,6 +3299,7 @@ static void CreatePerIsolateProperties(IsolateData* isolate_data,
   SetMethod(isolate, target, "rename", Rename);
   SetMethod(isolate, target, "ftruncate", FTruncate);
   SetMethod(isolate, target, "rmdir", RMDir);
+  SetMethod(isolate, target, "rimrafUnlinkSync", RimrafUnlinkSync);
   SetMethod(isolate, target, "mkdir", MKDir);
   SetMethod(isolate, target, "readdir", ReadDir);
   SetMethod(isolate, target, "internalModuleReadJSON", InternalModuleReadJSON);
@@ -3373,6 +3420,7 @@ void RegisterExternalReferences(ExternalReferenceRegistry* registry) {
   registry->Register(Rename);
   registry->Register(FTruncate);
   registry->Register(RMDir);
+  registry->Register(RimrafUnlinkSync);
   registry->Register(MKDir);
   registry->Register(ReadDir);
   registry->Register(InternalModuleReadJSON);

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -1619,16 +1619,18 @@ static void RimrafUnlinkSync(const FunctionCallbackInfo<Value>& args) {
     auto err = uv_fs_unlink(nullptr, &req, *path, nullptr);
     FS_SYNC_TRACE_END(unlink);
 
-    if (is_uv_error(err)) {
-      if (i < tries && retry_delay > 0 &&
-          std::find(retryable_errors.begin(), retryable_errors.end(), err) != retryable_errors.end()) {
-        sleep(i * retry_delay * 1e-3);
-      } else if (err == UV_ENOENT) {
-        break;
-      } else if (i == tries) {
-        env->ThrowUVException(err, nullptr, "unlink");
-        break;
-      }
+    if(!is_uv_error(err)) {
+      return;
+    }
+
+    if (i < tries && retry_delay > 0 &&
+        std::find(retryable_errors.begin(), retryable_errors.end(), err) != retryable_errors.end()) {
+      sleep(i * retry_delay * 1e-3);
+    } else if (err == UV_ENOENT) {
+      break;
+    } else if (i == tries) {
+      env->ThrowUVException(err, nullptr, "unlink");
+      break;
     }
   }
 }

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -1627,10 +1627,10 @@ static void RimrafUnlinkSync(const FunctionCallbackInfo<Value>& args) {
         std::find(retryable_errors.begin(), retryable_errors.end(), err) != retryable_errors.end()) {
       sleep(i * retry_delay * 1e-3);
     } else if (err == UV_ENOENT) {
-      break;
+      return;
     } else if (i == tries) {
       env->ThrowUVException(err, nullptr, "unlink");
-      break;
+      return;
     }
   }
 }

--- a/src/node_file.h
+++ b/src/node_file.h
@@ -3,7 +3,7 @@
 
 #if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
-#include <optional>
+//#include <optional>
 #include "aliased_buffer.h"
 #include "node_messaging.h"
 #include "node_snapshotable.h"

--- a/src/node_file_rimraf.cc
+++ b/src/node_file_rimraf.cc
@@ -1,0 +1,74 @@
+#include "node_file.h"  // NOLINT(build/include_inline)
+#include "node_file-inl.h"
+
+#if defined(_WIN32)
+#include<windows.h>           // for windows
+#else
+#include<unistd.h>               // for linux
+#endif
+
+namespace node {
+
+namespace fs {
+
+using v8::FunctionCallbackInfo;
+using v8::Int32;
+using v8::Value;
+
+#define TRACE_NAME(name) "fs.sync." #name
+#define GET_TRACE_ENABLED                                                      \
+  (*TRACE_EVENT_API_GET_CATEGORY_GROUP_ENABLED(                                \
+       TRACING_CATEGORY_NODE2(fs, sync)) != 0)
+#define FS_SYNC_TRACE_BEGIN(syscall, ...)                                      \
+  if (GET_TRACE_ENABLED)                                                       \
+    TRACE_EVENT_BEGIN(                                                         \
+        TRACING_CATEGORY_NODE2(fs, sync), TRACE_NAME(syscall), ##__VA_ARGS__);
+#define FS_SYNC_TRACE_END(syscall, ...)                                        \
+  if (GET_TRACE_ENABLED)                                                       \
+    TRACE_EVENT_END(                                                           \
+        TRACING_CATEGORY_NODE2(fs, sync), TRACE_NAME(syscall), ##__VA_ARGS__);
+
+static void UnlinkSync(const FunctionCallbackInfo<Value>& args) {
+  const int argc = args.Length();
+  CHECK_EQ(argc, 3);  // path, retries, retry delay
+
+  CHECK(args[1]->IsInt32());
+  CHECK(args[2]->IsInt32());
+
+  Environment* env = Environment::GetCurrent(args);
+  BufferValue path(env->isolate(), args[0]);
+
+  THROW_IF_INSUFFICIENT_PERMISSIONS(
+      env, permission::PermissionScope::kFileSystemWrite, path.ToStringView());
+
+  const auto tries = args[1].As<Int32>()->Value() + 1;
+  const auto retry_delay = args[2].As<Int32>()->Value();
+  constexpr std::array<int, 5> retryable_errors = {
+      EBUSY, EMFILE, ENFILE, ENOTEMPTY, EPERM};
+
+  uv_fs_t req;
+
+  for (int i = 1; i <= tries; i++) {
+    FS_SYNC_TRACE_BEGIN(unlink);
+    auto err = uv_fs_unlink(nullptr, &req, *path, nullptr);
+    FS_SYNC_TRACE_END(unlink);
+
+    if(!is_uv_error(err)) {
+      return;
+    }
+
+    if (i < tries && retry_delay > 0 &&
+        std::find(retryable_errors.begin(), retryable_errors.end(), err) != retryable_errors.end()) {
+      sleep(i * retry_delay * 1e-3);
+    } else if (err == UV_ENOENT) {
+      return;
+    } else if (i == tries) {
+      env->ThrowUVException(err, nullptr, "unlink");
+      return;
+    }
+  }
+}
+
+} // end namespace fs
+
+}  // end namespace node

--- a/typings/internalBinding/fs.d.ts
+++ b/typings/internalBinding/fs.d.ts
@@ -195,6 +195,8 @@ declare namespace InternalFSBinding {
   function rmdir(path: string, req: undefined, ctx: FSSyncContext): void;
   function rmdir(path: string, usePromises: typeof kUsePromises): Promise<void>;
 
+  function rimrafUnlinkSync(path: StringOrBuffer, maxRetries: number, retryDelay: number): void;
+
   function stat(path: StringOrBuffer, useBigint: boolean, req: FSReqCallback<Float64Array | BigUint64Array>): void;
   function stat(path: StringOrBuffer, useBigint: true, req: FSReqCallback<BigUint64Array>): void;
   function stat(path: StringOrBuffer, useBigint: false, req: FSReqCallback<Float64Array>): void;
@@ -275,6 +277,7 @@ export interface FsBinding {
   realpath: typeof InternalFSBinding.realpath;
   rename: typeof InternalFSBinding.rename;
   rmdir: typeof InternalFSBinding.rmdir;
+  rimrafUnlinkSync: typeof InternalFSBinding.rimrafUnlinkSync;
   stat: typeof InternalFSBinding.stat;
   symlink: typeof InternalFSBinding.symlink;
   unlink: typeof InternalFSBinding.unlink;


### PR DESCRIPTION
Refactor and port rimraf functionality to c++

Since a lot of the functions (besides _unlinkSync) in rimraf.js directly call wrapper functions around fs defined in rimraf.js, small refactoring would require us to write a lot of code that would ultimately get discarded. It will be easier to review the refactored codebase function by function (ideally commit by commit) in the end and avoid having to keep track of intermediary signatures to handle JS -> C++ communication.

**TODO:** 
- [ ] `rimraf`
- [ ] `rimrafSync`
- [ ] `rimrafPromises`
- [ ] `_rimraf`
- [ ] `_rmdir`
- [ ] `_rmdirSync`
- [ ] `_rmchildren`
- [x] `_unlinkSync`
- [ ] `fixWinEPERM`
- [x] `fixWinEPERMSync`

Once above functions are ported to C++, the dependency on rimraf.js should be removed the lazy loading logic associated with it should be removed from `lib/fs.js`. The final rimraf module should only expose rimraf and rimrafSync.