### PR TITLE
sqlite: remove node namespace

### DIFF
--- a/src/node_sqlite.cc
+++ b/src/node_sqlite.cc
@@ -9,6 +9,7 @@
 #include "path.h"
 #include "sqlite3.h"
 #include "util-inl.h"
+#include "util.h"
 
 #include <cinttypes>
 #include <string_view>
@@ -226,7 +227,7 @@ void DatabaseSync::Prepare(const FunctionCallbackInfo<Value>& args) {
     return;
   }
 
-  auto sql = Utf8Value(env->isolate(), args[0].As<String>());
+  Utf8Value sql(env->isolate(), args[0].As<String>());
   sqlite3_stmt* s = nullptr;
   int r = sqlite3_prepare_v2(db->connection_, *sql, -1, &s, 0);
   CHECK_ERROR_OR_THROW(env->isolate(), db->connection_, r, SQLITE_OK, void());
@@ -247,7 +248,7 @@ void DatabaseSync::Exec(const FunctionCallbackInfo<Value>& args) {
     return;
   }
 
-  auto sql = Utf8Value(env->isolate(), args[0].As<String>());
+  Utf8Value sql(env->isolate(), args[0].As<String>());
   int r = sqlite3_exec(db->connection_, *sql, nullptr, nullptr, nullptr);
   CHECK_ERROR_OR_THROW(env->isolate(), db->connection_, r, SQLITE_OK, void());
 }
@@ -335,7 +336,7 @@ bool StatementSync::BindParams(const FunctionCallbackInfo<Value>& args) {
         return false;
       }
 
-      auto utf8_key = Utf8Value(env()->isolate(), key);
+      Utf8Value utf8_key(env()->isolate(), key);
       int r = sqlite3_bind_parameter_index(statement_, *utf8_key);
       if (r == 0) {
         if (allow_bare_named_params_) {

--- a/src/node_sqlite.cc
+++ b/src/node_sqlite.cc
@@ -9,7 +9,6 @@
 #include "path.h"
 #include "sqlite3.h"
 #include "util-inl.h"
-#include "util.h"
 
 #include <cinttypes>
 #include <string_view>

--- a/src/node_sqlite.h
+++ b/src/node_sqlite.h
@@ -9,6 +9,7 @@
 #include "util.h"
 
 #include <map>
+#include <string_view>
 #include <unordered_set>
 
 namespace node {
@@ -20,7 +21,7 @@ class DatabaseSync : public BaseObject {
  public:
   DatabaseSync(Environment* env,
                v8::Local<v8::Object> object,
-               v8::Local<v8::String> location,
+               std::string_view location,
                bool open);
   void MemoryInfo(MemoryTracker* tracker) const override;
   static void New(const v8::FunctionCallbackInfo<v8::Value>& args);


### PR DESCRIPTION
Remove unnecessary use of node namespace from node_sqlite.cc